### PR TITLE
Fixed an bug when right click in the debug window

### DIFF
--- a/mWebSocket v1.0.0.mrc
+++ b/mWebSocket v1.0.0.mrc
@@ -726,7 +726,7 @@ alias -l _WebSocket.Debug {
 #_WebSocket_Debug end
 alias -l _WebSocket.Debug
 menu @WebSocketDebug {
-  $iif($WebSockDebug, Disable, Enable): WebSocketDebug
+  $iif($WebSockDebug, Disable, Enable): WebSockDebug
   -
   Clear:clear @WebSocketDebug
   -


### PR DESCRIPTION
When right click into the debug window in 'Disable' didn't disable the debugging if was enabled and the opposite.
